### PR TITLE
Fix rp crash when iframe navigates to external url

### DIFF
--- a/extensions/renderer/xwalk_module_system.cc
+++ b/extensions/renderer/xwalk_module_system.cc
@@ -109,8 +109,11 @@ void XWalkModuleSystem::SetModuleSystemInContext(
 // static
 void XWalkModuleSystem::ResetModuleSystemFromContext(
     v8::Handle<v8::Context> context) {
-  delete GetModuleSystemFromContext(context);
-  SetModuleSystemInContext(std::unique_ptr<XWalkModuleSystem>(), context);
+  XWalkModuleSystem* module_system = GetModuleSystemFromContext(context);
+  if (module_system) {
+    delete module_system;
+    SetModuleSystemInContext(std::unique_ptr<XWalkModuleSystem>(), context);
+  }
 }
 
 void XWalkModuleSystem::RegisterExtensionModule(

--- a/runtime/renderer/injected_bundle.cc
+++ b/runtime/renderer/injected_bundle.cc
@@ -29,6 +29,7 @@
 #include "common/profiler.h"
 #include "extensions/renderer/runtime_ipc_client.h"
 #include "extensions/renderer/xwalk_extension_renderer_controller.h"
+#include "extensions/renderer/xwalk_module_system.h"
 #include "extensions/renderer/widget_module.h"
 
 namespace runtime {
@@ -92,6 +93,11 @@ extern "C" void DynamicPluginStartSession(const char* tizen_id,
                                           const char* /*theme*/,
                                           const char* base_url) {
   SCOPE_PROFILE();
+
+  // Initialize context's aligned pointer in embedder data with null
+  extensions::XWalkModuleSystem::SetModuleSystemInContext(
+      std::unique_ptr<extensions::XWalkModuleSystem>(), context);
+
   LOGGER(DEBUG) << "InjectedBundle::DynamicPluginStartSession !!" << tizen_id;
   if (base_url == NULL || common::utils::StartsWith(base_url, "http")) {
     LOGGER(ERROR) << "External url not allowed plugin loading.";


### PR DESCRIPTION
XWalk tried to delete any XWalkModuleSystem whether it is set or not.

So, adds code about
1. Setting XWalkModuleSystem in v8::Context with null before checking
   whether base_url is external or not in DynamicPlginStartSession()
2. Deleting XWalkModuleSystem after checking whether the XwalkModuleSystem
   is not null in XWalkModuleSystem::ResetModuleSystemFromContext()
