### PR TITLE
Fix popup error due to uninitialized members

### DIFF
--- a/runtime/browser/popup.cc
+++ b/runtime/browser/popup.cc
@@ -285,9 +285,13 @@ void Popup::Result(bool is_positive) {
     result_button_ = is_positive;
   }
   if (enable_entry_ && !!entry1_) {
-    result_entry1_ = elm_entry_entry_get(entry1_);
+    const char* text = elm_entry_entry_get(entry1_);
+    if (text)
+      result_entry1_ = text;
     if (!!entry2_) {
-      result_entry2_ = elm_entry_entry_get(entry2_);
+      text = elm_entry_entry_get(entry2_);
+      if (text)
+        result_entry2_ = text;
     }
   }
   if (enable_check_box_) {
@@ -298,7 +302,10 @@ void Popup::Result(bool is_positive) {
 }
 
 Popup::Popup(Evas_Object* popup, Evas_Object* box)
-  : popup_(popup), box_(box) {}
+  : popup_(popup), box_(box), button1_(NULL), button2_(NULL),
+    entry1_(NULL), entry2_(NULL), check_box_(NULL), user_data_(NULL),
+    enable_button_(false), result_button_(false), enable_entry_(false),
+    enable_check_box_(false), result_check_box_(false) {}
 
 Popup::~Popup() {
   if (popup_)


### PR DESCRIPTION
Add code to initialize member variables in Popup's constructor and
to check whether the value from elm_entry_entry_get() is null or not

When cert popups are opened in succession, elm_entry_entry_get() returns
null occationally. So it needs null check.

Until now, Popup's boolean member variables have not initialized. So
Popup::Result() enters code about entry although Popup doesn't use entry.
It needs to initialize member variables with proper values.
