### PR TITLE
Fix ExtName() that was returning the wrong value

### DIFF
--- a/common/file_utils.cc
+++ b/common/file_utils.cc
@@ -54,6 +54,9 @@ std::string ExtName(const std::string& path) {
   size_t last_dot = path.find_last_of(".");
   if (last_dot != 0 && last_dot != std::string::npos) {
     std::string ext = path.substr(last_dot);
+    size_t end_of_ext = ext.find_first_of("?#");
+    if (end_of_ext != std::string::npos)
+      ext = ext.substr(0, end_of_ext);
     std::transform(ext.begin(), ext.end(), ext.begin(), ::tolower);
     return ext;
   } else {


### PR DESCRIPTION
  ExtName() function, which returns a file extension, was returning the wrong extention
  when there is '?' or '#' after a 'html' file path.

  (ex) If path is "file://abc.html?test=c", returned value was ".html?test=c".
       Now it is corrected to ".html"
