### PR TITLE
Fix AppControl reload="disable" behavior bug

### DIFF
--- a/runtime/browser/web_application.h
+++ b/runtime/browser/web_application.h
@@ -118,7 +118,6 @@ class WebApplication : public WebView::EventListener {
   std::unique_ptr<common::LocaleManager> locale_manager_;
   std::unique_ptr<common::ApplicationData> app_data_;
   std::unique_ptr<common::ResourceManager> resource_manager_;
-  std::unique_ptr<common::AppControl> received_appcontrol_;
   std::function<void(void)> terminator_;
   int security_model_version_;
   std::string csp_rule_;


### PR DESCRIPTION
- WebView::GetUrl() was returing localized URL, But we compare with relative URL
- res->uri convert to localized url and compare with webview::GetUrl()
- Remove unused instance variable
