### PR TITLE
Call terminator of WebApplication when receive tizen://exit

### DIFF
--- a/runtime/browser/web_application.h
+++ b/runtime/browser/web_application.h
@@ -46,6 +46,7 @@ class WebApplication : public WebView::EventListener {
   void Launch(std::unique_ptr<common::AppControl> appcontrol);
   void Resume();
   void Suspend();
+  void Terminate();
 
   std::string data_path() const { return app_data_path_; }
   void set_terminator(std::function<void(void)> terminator)


### PR DESCRIPTION
Application should call the terminator of WebApplication to terminate
application in normal procedure when receive the runtime message
'tizen://exit' from Device APIs.
