### PR TITLE
Fix widget size issue

### DIFF
--- a/extensions/internal/widget/widget_api.js
+++ b/extensions/internal/widget/widget_api.js
@@ -67,12 +67,16 @@ function Widget() {
       writable: false
     },
     "height": {
-      value: window && window.innerHeight || 0,
-      writable: false
+      get: function() {
+        return window && window.innerHeight || 0;
+      },
+      configurable: false
     },
     "width": {
-      value: window && window.innerWidth || 0,
-      writable: false
+      get: function() {
+        return window && window.innerWidth || 0;
+      },
+      configurable: false
     },
     "preferences": {
       value: preference_,

--- a/runtime/browser/native_window.cc
+++ b/runtime/browser/native_window.cc
@@ -178,6 +178,9 @@ void NativeWindow::SetContent(Evas_Object* content) {
   elm_object_part_content_set(focus_, "elm.swallow.content", content);
   elm_object_focus_set(focus_, EINA_TRUE);
   content_ = content;
+
+  // attached webview was resized by evas_norender API
+  evas_norender(evas_object_evas_get(window_));
 }
 
 void NativeWindow::DidRotation(int degree) {

--- a/runtime/browser/web_application.cc
+++ b/runtime/browser/web_application.cc
@@ -385,9 +385,10 @@ void WebApplication::Launch(std::unique_ptr<common::AppControl> appcontrol) {
   STEP_PROFILE_END("OnCreate -> URL Set");
   STEP_PROFILE_START("URL Set -> Rendered");
 
+  window_->SetContent(view->evas_object());
   view->LoadUrl(res->uri(), res->mime());
   view_stack_.push_front(view);
-  window_->SetContent(view->evas_object());
+
 
   if (appcontrol->data(kDebugKey) == "true") {
     debug_mode_ = true;


### PR DESCRIPTION
widget.width and widget.height getting wrong values on OnLoad handler

Reason
1. WebView was not resized before running idler
2. widget.width/height value was fixed with initial value

Solution
1. evas_norender was resized the view
2. widget.width/height value getter change
