### PR TITLE
Revert "config.xml parameter change: on-reset -> reload"

### DIFF
--- a/common/resource_manager.cc
+++ b/common/resource_manager.cc
@@ -243,7 +243,7 @@ std::unique_ptr<ResourceManager::Resource> ResourceManager::GetMatchedResource(
   if (!app_control_info.src().empty()) {
     return std::unique_ptr<Resource>(new Resource(
       InsertPrefixPath(app_control_info.src()),
-                       app_control_info.reload() == "disable" ? false : true));
+                       app_control_info.onreset() == "disable" ? false : true));
   }
   return GetDefaultResource();
 }


### PR DESCRIPTION
The related commit of manifest-parser was reverted.
https://review.tizen.org/gerrit/#/c/48171/

This will applied again when the commit is merged to tizen.org.
