### PR TITLE
Fix RuntimeIPCClient to set routing_id in V8Context

### DIFF
--- a/extensions/renderer/runtime_ipc_client.h
+++ b/extensions/renderer/runtime_ipc_client.h
@@ -45,26 +45,29 @@ class RuntimeIPCClient {
   static RuntimeIPCClient* GetInstance();
 
   // Send message to BrowserProcess without reply
-  void SendMessage(const std::string& type, const std::string& value);
+  void SendMessage(v8::Handle<v8::Context> context,
+                   const std::string& type, const std::string& value);
 
   // Send message to BrowserProcess synchronous with reply
-  std::string SendSyncMessage(const std::string& type,
+  std::string SendSyncMessage(v8::Handle<v8::Context> context,
+                              const std::string& type,
                               const std::string& value);
 
   // Send message to BrowserProcess asynchronous,
   // reply message will be passed to callback function.
-  void SendAsyncMessage(const std::string& type, const std::string& value,
+  void SendAsyncMessage(v8::Handle<v8::Context> context,
+                        const std::string& type, const std::string& value,
                         ReplyCallback callback);
 
   void HandleMessageFromRuntime(const Ewk_IPC_Wrt_Message_Data* msg);
 
-  int routing_id() const { return routing_id_; }
-  void set_routing_id(int routing_id) { routing_id_ = routing_id; }
+  int GetRoutingId(v8::Handle<v8::Context> context);
+
+  void SetRoutingId(v8::Handle<v8::Context> context, int routing_id);
 
  private:
   RuntimeIPCClient();
 
-  int routing_id_;
   std::map<std::string, ReplyCallback> callbacks_;
 };
 

--- a/extensions/renderer/xwalk_extension_module.cc
+++ b/extensions/renderer/xwalk_extension_module.cc
@@ -411,7 +411,8 @@ void XWalkExtensionModule::SendRuntimeMessageCallback(
   }
 
   RuntimeIPCClient* rc = RuntimeIPCClient::GetInstance();
-  rc->SendMessage(std::string(*type), data_str);
+  rc->SendMessage(module->module_system_->GetV8Context(),
+                  std::string(*type), data_str);
 
   result.Set(true);
 }
@@ -436,7 +437,9 @@ void XWalkExtensionModule::SendRuntimeSyncMessageCallback(
   }
 
   RuntimeIPCClient* rc = RuntimeIPCClient::GetInstance();
-  std::string reply = rc->SendSyncMessage(std::string(*type), data_str);
+  std::string reply = rc->SendSyncMessage(
+      module->module_system_->GetV8Context(),
+      std::string(*type), data_str);
 
   result.Set(v8::String::NewFromUtf8(isolate, reply.c_str()));
 }
@@ -488,7 +491,8 @@ void XWalkExtensionModule::SendRuntimeAsyncMessageCallback(
   };
 
   RuntimeIPCClient* rc = RuntimeIPCClient::GetInstance();
-  rc->SendAsyncMessage(std::string(*type), value_str, callback);
+  rc->SendAsyncMessage(module->module_system_->GetV8Context(),
+                       std::string(*type), value_str, callback);
 
   result.Set(true);
 }

--- a/runtime/renderer/injected_bundle.cc
+++ b/runtime/renderer/injected_bundle.cc
@@ -109,7 +109,7 @@ extern "C" void DynamicPluginStartSession(const char* tizen_id,
   // Initialize RuntimeIPCClient
   extensions::RuntimeIPCClient* rc =
       extensions::RuntimeIPCClient::GetInstance();
-  rc->set_routing_id(routing_handle);
+  rc->SetRoutingId(context, routing_handle);
   STEP_PROFILE_END("Initialize RuntimeIPCClient");
 
   extensions::XWalkExtensionRendererController& controller =


### PR DESCRIPTION
Chromium-EFL creates a routing_id for each global context.
The RuntimeIPCClient should manage the routing_id for multiple context.
