### PR TITLE
Bypass descryption in case that file's size is 0

### DIFF
--- a/common/resource_manager.cc
+++ b/common/resource_manager.cc
@@ -580,6 +580,11 @@ std::string ResourceManager::DecryptResource(const std::string& path) {
   // Read filesize
   fseek(src, 0, SEEK_END);
   size_t src_len = ftell(src);
+  if (src_len == 0) {
+    // if the file exists and is empty, bypass it
+    fclose(src);
+    return path;
+  }
   rewind(src);
 
   // Read buffer from the source file


### PR DESCRIPTION
Until now, crosswalk-tizen does descryption although the files' contents
are empty(the file size is 0). It's ineffective.
Fix code to bypass it in the case.
