### PR TITLE
Fix using initCustomEvent() of CustomEvent

### DIFF
--- a/extensions/internal/widget/widget_api.js
+++ b/extensions/internal/widget/widget_api.js
@@ -16,7 +16,7 @@
 
 var dispatchStorageEvent = function(key, oldValue, newValue) {
   var evt = document.createEvent("CustomEvent");
-  evt.initCustomEvent("storage", true, true);
+  evt.initCustomEvent("storage", true, true, null);
   evt.key = key;
   evt.oldValue = oldValue;
   evt.newValue = newValue;

--- a/runtime/browser/web_application.cc
+++ b/runtime/browser/web_application.cc
@@ -63,7 +63,7 @@ const char* kPortKey = "port";
 const char* kAppControlEventScript =
     "(function(){"
     "var __event = document.createEvent(\"CustomEvent\");\n"
-    "__event.initCustomEvent(\"appcontrol\", true, true);\n"
+    "__event.initCustomEvent(\"appcontrol\", true, true, null);\n"
     "document.dispatchEvent(__event);\n"
     "\n"
     "for (var i=0; i < window.frames.length; i++)\n"
@@ -72,7 +72,7 @@ const char* kAppControlEventScript =
 const char* kBackKeyEventScript =
     "(function(){"
     "var __event = document.createEvent(\"CustomEvent\");\n"
-    "__event.initCustomEvent(\"tizenhwkey\", true, true);\n"
+    "__event.initCustomEvent(\"tizenhwkey\", true, true, null);\n"
     "__event.keyName = \"back\";\n"
     "document.dispatchEvent(__event);\n"
     "\n"
@@ -82,7 +82,7 @@ const char* kBackKeyEventScript =
 const char* kMenuKeyEventScript =
     "(function(){"
     "var __event = document.createEvent(\"CustomEvent\");\n"
-    "__event.initCustomEvent(\"tizenhwkey\", true, true);\n"
+    "__event.initCustomEvent(\"tizenhwkey\", true, true, null);\n"
     "__event.keyName = \"menu\";\n"
     "document.dispatchEvent(__event);\n"
     "\n"


### PR DESCRIPTION
CustomEvent.initCustomEvent() function is used with 3 arguments,
fourth being optional.
In chromium m47 IDL for CustomEvent.initCustomEvent() was changed,
and now it requires all four arguments to be present.
Calls with 3 arguments fail, and no event is received in a web
application.
