### PR TITLE
Add a include for bundle_internal.h

### DIFF
--- a/common/app_control.cc
+++ b/common/app_control.cc
@@ -18,6 +18,7 @@
 
 #include <appsvc.h>
 #include <app_control_internal.h>
+#include <bundle_internal.h>
 
 #include <algorithm>
 #include <memory>


### PR DESCRIPTION
Bundle API will be changed to refer bundle.h and bundle_internal
both.
