### PR TITLE
Change trampoline algorithm for top level extensions

### DIFF
--- a/extensions/renderer/xwalk_module_system.cc
+++ b/extensions/renderer/xwalk_module_system.cc
@@ -470,10 +470,14 @@ void XWalkModuleSystem::MarkModulesWithTrampoline() {
 
   ExtensionModules::iterator it = extension_modules_.begin();
   while (it != extension_modules_.end()) {
-    it = std::adjacent_find(it, extension_modules_.end(),
-                            &ExtensionModuleEntry::IsPrefix);
-    if (it == extension_modules_.end())
-      break;
+    const std::string& n = (*it).name;
+    // Top level modules won't be mared with trampoline
+    if (std::find(n.begin(), n.end(), '.') != n.end()) {
+      it = std::adjacent_find(it, extension_modules_.end(),
+                              &ExtensionModuleEntry::IsPrefix);
+      if (it == extension_modules_.end())
+        break;
+    }
     it->use_trampoline = false;
     ++it;
   }


### PR DESCRIPTION
Top level extensions (tizen, xwalk) shouldn't be trampoline module
because of security issues.
