### PR TITLE
Handle backbutton-presence of tizen:setting in config.xml

### DIFF
--- a/runtime/browser/web_application.cc
+++ b/runtime/browser/web_application.cc
@@ -600,6 +600,12 @@ void WebApplication::OnHardwareKey(WebView* view, const std::string& keyname) {
                      : true;
   if (enabled && kKeyNameBack == keyname) {
     view->EvalJavascript(kBackKeyEventScript);
+    // NOTE: This code is added for backward compatibility.
+    // If the 'backbutton_presence' is true, WebView should be navigated back.
+    if (app_data_->setting_info() &&
+        app_data_->setting_info()->backbutton_presence()) {
+      view->Backward();
+    }
   } else if (enabled && kKeyNameMenu == keyname) {
     view->EvalJavascript(kMenuKeyEventScript);
   }

--- a/runtime/browser/web_view.cc
+++ b/runtime/browser/web_view.cc
@@ -53,6 +53,10 @@ void WebView::Reload() {
   impl_->Reload();
 }
 
+void WebView::Backward() {
+  impl_->Backward();
+}
+
 void WebView::SetVisibility(bool show) {
   impl_->SetVisibility(show);
 }

--- a/runtime/browser/web_view.h
+++ b/runtime/browser/web_view.h
@@ -98,6 +98,7 @@ class WebView {
   void Suspend();
   void Resume();
   void Reload();
+  void Backward();
   void SetVisibility(bool show);
   bool EvalJavascript(const std::string& script);
   void SetAppInfo(const std::string& app_name, const std::string& version);

--- a/runtime/browser/web_view_impl.cc
+++ b/runtime/browser/web_view_impl.cc
@@ -129,6 +129,10 @@ void WebViewImpl::Reload() {
   ewk_view_reload(ewk_view_);
 }
 
+void WebViewImpl::Backward() {
+  ewk_view_back(ewk_view_);
+}
+
 void WebViewImpl::SetVisibility(bool show) {
   ewk_view_visibility_set(ewk_view_, show ? EINA_TRUE : EINA_FALSE);
 }
@@ -813,7 +817,6 @@ void WebViewImpl::InitUsermediaCallback() {
       LOGGER(DEBUG) << "Getusermedia Permission Result : " << result;
       ewk_user_media_permission_reply(request, result);
     };
-    std::string test = url.str();
     self->listener_->OnUsermediaPermissionRequest(self->view_,
                                                   url.str(),
                                                   result_handler);
@@ -851,8 +854,9 @@ void WebViewImpl::OnKeyEvent(Eext_Callback_Type key_type) {
     return;
   }
 
-  if (listener_)
+  if (listener_) {
     listener_->OnHardwareKey(view_, keyname);
+  }
 }
 
 void WebViewImpl::SetEventListener(WebView::EventListener* listener) {

--- a/runtime/browser/web_view_impl.h
+++ b/runtime/browser/web_view_impl.h
@@ -41,6 +41,7 @@ class WebViewImpl {
   void Suspend();
   void Resume();
   void Reload();
+  void Backward();
   void SetVisibility(bool show);
   bool EvalJavascript(const std::string& script);
   void SetAppInfo(const std::string& app_name, const std::string& version);


### PR DESCRIPTION
This handler is added for backward compatibility with Tizen 2.x.
If this option is enabled, page should be navigated back in history
when the back-button is pressed.
