### PR TITLE
Adjust DynamicPlugin* funtions to library version 1

### DIFF
--- a/runtime/renderer/injected_bundle.cc
+++ b/runtime/renderer/injected_bundle.cc
@@ -102,6 +102,10 @@ class BundleGlobalData {
 
 }  //  namespace runtime
 
+extern "C" unsigned int DynamicPluginVersion(void) {
+  return 1;
+}
+
 extern "C" void DynamicSetWidgetInfo(const char* tizen_id) {
   SCOPE_PROFILE();
   LOGGER(DEBUG) << "InjectedBundle::DynamicSetWidgetInfo !!" << tizen_id;
@@ -112,9 +116,6 @@ extern "C" void DynamicSetWidgetInfo(const char* tizen_id) {
 extern "C" void DynamicPluginStartSession(const char* tizen_id,
                                           v8::Handle<v8::Context> context,
                                           int routing_handle,
-                                          double /*scale*/,
-                                          const char* /*bundle*/,
-                                          const char* /*theme*/,
                                           const char* base_url) {
   SCOPE_PROFILE();
 


### PR DESCRIPTION
Along with ewk_context_tizen_app_id_set function introduction
by chromium-efl, newer version of DynamicPlugin library has been
provided. See sample file ([1]) of chromium-efl ([2]) repository.

[1] tizen_src/ewk/unittest/resources/ewk_context/injected_bundle/chromium/bundle_sample.cc
[2] https://review.tizen.org/gerrit/#/admin/projects/platform/framework/web/chromium-efl
