### PR TITLE
Request sync after system call for change privilege of thread

### DIFF
--- a/runtime/browser/prelauncher.cc
+++ b/runtime/browser/prelauncher.cc
@@ -70,13 +70,8 @@ void ChangePrivilegeForThreads(const std::string& appid) {
       if (tid == current_tid)
         continue;
       syscall(__NR_tkill, tid, SIGUSR1);
-
-      // It is workaround code
-      // Delete Me, If does not crashed on Note4
-      // I don't know why crashed in Kernel with below log
-      // unhandled level 2 translation fault (11) at 0x00000080, esr 0x92000006
-      LOGGER(DEBUG) << "Send signal " << tid;
     }
+    sync();
     closedir(dir);
   }
   signal(SIGUSR1, oldhandler);


### PR DESCRIPTION
In this logic, the system call accesses file system about thread. 
Sometimes, error occur when change privilege with system call, because of file system do not change immediately after system call.
So, add sync logic after the system call. It can commit file system cash to disk.
Also remove logs for make delay (with comment).
