### PR TITLE
Fix SplashScreen hide delegate function

### DIFF
--- a/extensions/internal/splash_screen/splash_screen_api.js
+++ b/extensions/internal/splash_screen/splash_screen_api.js
@@ -14,8 +14,9 @@
  *    limitations under the License.
  */
 
-var native = new xwalk.utils.NativeManager(extension);
-
+var sendRuntimeMessage = extension.sendRuntimeMessage ||  function() {
+  console.error('Runtime did not implement extension.sendRuntimeMessage!');
+};
 window.screen.show = function() {
-  native.sendRuntimeMessage('tizen://hide_splash_screen');
+  sendRuntimeMessage('tizen://hide_splash_screen');
 };


### PR DESCRIPTION
xwalk.utils can't use in Runtime widget
Change to original extension.sendRuntimeMessage API
