### PR TITLE
Unregister extensions and instances when application exits

### DIFF
--- a/extensions/common/xwalk_extension.cc
+++ b/extensions/common/xwalk_extension.cc
@@ -49,7 +49,6 @@ XWalkExtension::XWalkExtension(const std::string& path,
 XWalkExtension::~XWalkExtension() {
   if (!initialized_)
     return;
-
   if (shutdown_callback_)
     shutdown_callback_(xw_extension_);
   XWalkExtensionAdapter::GetInstance()->UnregisterExtension(this);

--- a/extensions/common/xwalk_extension_adapter.cc
+++ b/extensions/common/xwalk_extension_adapter.cc
@@ -48,8 +48,10 @@ void XWalkExtensionAdapter::UnregisterExtension(XWalkExtension* extension) {
     LOGGER(WARN) << "xw_extension (" << xw_extension << ") is invalid.";
     return;
   }
-  if (extension_map_.find(xw_extension) != extension_map_.end())
-    extension_map_.erase(xw_extension);
+  auto it = extension_map_.find(xw_extension);
+  if (it != extension_map_.end()) {
+    extension_map_.erase(it);
+  }
 }
 
 void XWalkExtensionAdapter::RegisterInstance(
@@ -70,8 +72,10 @@ void XWalkExtensionAdapter::UnregisterInstance(
     LOGGER(WARN) << "xw_instance (" << xw_instance << ") is invalid.";
     return;
   }
-  if (instance_map_.find(xw_instance) != instance_map_.end())
-    instance_map_.erase(xw_instance);
+  auto it = instance_map_.find(xw_instance);
+  if (it != instance_map_.end()) {
+    instance_map_.erase(it);
+  }
 }
 
 const void* XWalkExtensionAdapter::GetInterface(const char* name) {

--- a/extensions/common/xwalk_extension_manager.cc
+++ b/extensions/common/xwalk_extension_manager.cc
@@ -108,6 +108,13 @@ void XWalkExtensionManager::LoadExtensions(bool meta_only) {
   }
 }
 
+void XWalkExtensionManager::UnloadExtensions() {
+  for (auto it = extensions_.begin(); it != extensions_.end(); ++it) {
+    delete it->second;
+  }
+  extensions_.clear();
+}
+
 bool XWalkExtensionManager::RegisterSymbols(XWalkExtension* extension) {
   std::string name = extension->name();
 

--- a/extensions/common/xwalk_extension_manager.h
+++ b/extensions/common/xwalk_extension_manager.h
@@ -26,6 +26,8 @@ class XWalkExtensionManager : public XWalkExtension::XWalkExtensionDelegate {
   void LoadExtensions(bool meta_only = true);
   void PreloadExtensions();
 
+  void UnloadExtensions();
+
  private:
   // override
   void GetRuntimeVariable(const char* key, char* value, size_t value_len);

--- a/extensions/common/xwalk_extension_server.cc
+++ b/extensions/common/xwalk_extension_server.cc
@@ -37,6 +37,14 @@ void XWalkExtensionServer::Preload() {
   manager_.PreloadExtensions();
 }
 
+void XWalkExtensionServer::Shutdown() {
+  for (auto it = instances_.begin(); it != instances_.end(); ++it) {
+    delete it->second;
+  }
+  instances_.clear();
+  manager_.UnloadExtensions();
+}
+
 Json::Value XWalkExtensionServer::GetExtensions() {
   Json::Value out;
   auto extensions = manager_.extensions();

--- a/extensions/common/xwalk_extension_server.h
+++ b/extensions/common/xwalk_extension_server.h
@@ -28,6 +28,8 @@ class XWalkExtensionServer {
 
   void HandleIPCMessage(Ewk_IPC_Wrt_Message_Data* data);
 
+  void Shutdown();
+
  private:
   XWalkExtensionServer();
   virtual ~XWalkExtensionServer();

--- a/runtime/browser/web_application.cc
+++ b/runtime/browser/web_application.cc
@@ -496,6 +496,8 @@ void WebApplication::Terminate() {
   } else {
     elm_exit();
   }
+  auto extension_server = extensions::XWalkExtensionServer::GetInstance();
+  extension_server->Shutdown();
 }
 
 void WebApplication::OnCreatedNewWebView(WebView* /*view*/, WebView* new_view) {
@@ -542,7 +544,6 @@ void WebApplication::OnClosedWebView(WebView* view) {
 
 void WebApplication::OnReceivedWrtMessage(WebView* /*view*/,
                                           Ewk_IPC_Wrt_Message_Data* msg) {
-  SCOPE_PROFILE();
   Eina_Stringshare* msg_type = ewk_ipc_wrt_message_data_type_get(msg);
 
 #define TYPE_BEGIN(x) (!strncmp(msg_type, x, strlen(x)))


### PR DESCRIPTION
In single process model, the extension server is running in the mainloop
of the browser thread. So the extension server can't receive ewk_ipc message
after the mainloop is terminated. WebApplication calls the Shutdown() method
of ExtensionServer explicitly now.
